### PR TITLE
Spawn openerp using same python executable

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -13,6 +13,7 @@ import signal
 import simplejson
 import subprocess
 import time
+import sys
 
 import dateutil.parser
 import requests
@@ -528,6 +529,7 @@ class runbot_build(osv.osv):
 
             # commandline
             cmd = [
+                sys.executable,
                 server_path,
                 "--no-xmlrpcs",
                 "--xmlrpc-port=%d" % build.port,


### PR DESCRIPTION
Solves issues of spawning wrong version of python or popping out of virtualenv
