### PR TITLE
Actual support for openerp -> odoo

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -482,6 +482,7 @@ class runbot_build(osv.osv):
         for build in self.browse(cr, uid, ids, context=None):
             if os.path.exists(build.path('odoo')):
                 return build.path('odoo', *l)
+            return build.path('openerp', *l)
 
     def checkout(self, cr, uid, ids, context=None):
         for build in self.browse(cr, uid, ids, context=context):


### PR DESCRIPTION
For every problem there's a solution which is simple, obvious and wrong.

That's the case of #14, the openerp path hardcoding had metastasised and spread through the whole build model, every instance needs to be excised for the rename branch to have any chance of survival, and the previous operation only removed a single spot, so we need to cut the patient open again.
