### PR TITLE
Add missing o2m which is referred to in web view

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -373,6 +373,7 @@ class runbot_branch(osv.osv):
         'sticky': fields.boolean('Sticky'),
         'coverage': fields.boolean('Coverage'),
         'state': fields.char('Status'),
+        'builds': fields.one2many('runbot.build', 'branch_id', 'Builds'),
     }
 
 class runbot_build(osv.osv):


### PR DESCRIPTION
Fix a bug when rendering the webpage:

```
500: Internal Server Error
Error

Error message:

"'runbot.branch' object has no attribute 'builds'" while evaluating
's2h(br.builds[0].job_age)'

QWeb

Error message:

Could not evaluate expression 's2h(br.builds[0].job_age)'

The error occured while rendering the template runbot.repo and evaluating the following expression: s2h(br.builds[0].job_age)
```
