### PR TITLE
[IMP] save committer date at creation

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -277,6 +277,7 @@ class runbot_repo(osv.osv):
                     'name': sha,
                     'author': author,
                     'subject': subject,
+                    'date': dateutil.parser.parse(date[:19])
                 }
                 Build.create(cr, uid, build_info)
 

--- a/runbot/runbot.xml
+++ b/runbot/runbot.xml
@@ -185,6 +185,7 @@
                     <filter string="Status" domain="[]" context="{'group_by':'state'}"/>
                     <filter string="Result" domain="[]" context="{'group_by':'result'}"/>
                     <filter string="Start" domain="[]" context="{'group_by':'job_start'}"/>
+                    <filter string="Create Date" domain="[]" context="{'group_by':'create_date'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
also, add a create_date filter in the build search view.  It allows
interesting statistics to be displayed in the graph view.
