### PR TITLE
[FIX][runbot] Add context parameter

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -370,9 +370,9 @@ class runbot_repo(osv.osv):
         Build.reap(cr, uid, build_ids)
 
     def cron(self, cr, uid, ids=None, context=None):
-        ids = self.search(cr, uid, [('auto', '=', True)])
-        self.update(cr, uid, ids)
-        self.scheduler(cr, uid, ids)
+        ids = self.search(cr, uid, [('auto', '=', True)], context=context)
+        self.update(cr, uid, ids, context=context)
+        self.scheduler(cr, uid, ids, context=context)
         self.reload_nginx(cr, uid, context=context)
 
 class runbot_branch(osv.osv):


### PR DESCRIPTION
Cron function receive context parameter but no send it.
This is important for manage inherit function
