### PR TITLE
[REF][runbot] Add support nginx multi-platform

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -375,7 +375,7 @@ class runbot_repo(osv.osv):
                 os.kill(pid, signal.SIGHUP)
             except Exception:
                 _logger.debug('start nginx')
-                run(['/usr/sbin/nginx', '-p', nginx_dir, '-c', 'nginx.conf'])
+                run([openerp.tools.find_in_path("nginx"), '-p', os.path.join(nginx_dir, ''), '-c', 'nginx.conf'])
 
     def killall(self, cr, uid, ids=None, context=None):
         # kill switch


### PR DESCRIPTION
The nginx app path is set with a static path.
This path change in other OS (MAC OS the path of nginx is /opt/local/sbin/nginx)
The function openerp.tools.find_in_path() work fine for this case.

The nginx_dir requires the latest os.split in other OS and also works on linux.
