### PR TITLE
[REF][runbot] Add environment to subprocess

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -704,7 +704,7 @@ class runbot_build(osv.osv):
 
         return cmd, modules
 
-    def spawn(self, cmd, lock_path, log_path, cpu_limit=None, shell=False, showstderr=False):
+    def spawn(self, cmd, lock_path, log_path, cpu_limit=None, shell=False, showstderr=False, env=None):
         def preexec_fn():
             os.setsid()
             if cpu_limit:
@@ -718,11 +718,13 @@ class runbot_build(osv.osv):
             lock(lock_path)
         out=open(log_path,"w")
         _logger.debug("spawn: %s stdout: %s", ' '.join(cmd), log_path)
+        if env is None:
+            env = {}
         if showstderr:
             stderr = out
         else:
             stderr = open(os.devnull, 'w')
-        p=subprocess.Popen(cmd, stdout=out, stderr=stderr, preexec_fn=preexec_fn, shell=shell)
+        p=subprocess.Popen(cmd, stdout=out, stderr=stderr, preexec_fn=preexec_fn, shell=shell, env=env)
         return p.pid
 
     def github_status(self, cr, uid, ids, context=None):


### PR DESCRIPTION
Subprocess function you can send it a custom enviroment.
This is important for inherit job_XX

For example, pylint needs build.path in principal path for get all environment of import's python.

NOTE: If you not set it will be use local environment to work normally as it does currently
