### PR TITLE
Change hostname function to get fqdn

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -148,7 +148,7 @@ def uniq_list(l):
     return OrderedDict.fromkeys(l).keys()
 
 def fqdn():
-    return socket.gethostname()
+    return socket.getfqdn()
 
 #----------------------------------------------------------
 # RunBot Models


### PR DESCRIPTION
Use the fqdn function so we are sure to always have the fqdn and not only the subdomain