### PR TITLE
[IMP] Deprecate unused fields

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -178,9 +178,9 @@ class runbot_repo(osv.osv):
         'name': fields.char('Repository', required=True),
         'path': fields.function(_get_path, type='char', string='Directory', readonly=1),
         'base': fields.function(_get_base, type='char', string='Base URL', readonly=1),
-        'testing': fields.integer('Concurrent Testing'),
-        'running': fields.integer('Concurrent Running'),
-        'jobs': fields.char('Jobs'),
+        'testing': fields.integer('Concurrent Testing', deprecated=True),
+        'running': fields.integer('Concurrent Running', deprecated=True),
+        'jobs': fields.char('Jobs', deprecated=True),
         'nginx': fields.boolean('Nginx'),
         'auto': fields.boolean('Auto'),
         'duplicate_id': fields.many2one('runbot.repo', 'Duplicate repo', help='Repository for finding duplicate builds'),
@@ -194,8 +194,6 @@ class runbot_repo(osv.osv):
         'group_ids': fields.many2many('res.groups', string='Limited to groups'),
     }
     _defaults = {
-        'testing': 1,
-        'running': 1,
         'auto': True,
     }
 

--- a/runbot/runbot.xml
+++ b/runbot/runbot.xml
@@ -18,10 +18,7 @@
                         <button name="killall" type="object" string="Killall" groups="runbot.group_runbot_admin"/>
                     </div>
                     <group string="Params">
-                        <field name="testing"/>
-                        <field name="running"/>
                         <field name="auto"/>
-                        <field name="jobs"/>
                         <field name="nginx"/>
                         <field name="duplicate_id"/>
                         <field name="dependency_ids" widget="many2many_tags"/>

--- a/runbot/runbot.xml
+++ b/runbot/runbot.xml
@@ -35,8 +35,6 @@
         <field name="arch" type="xml">
             <tree string="repos">
                 <field name="name"/>
-                <field name="testing"/>
-                <field name="running"/>
                 <field name="auto"/>
             </tree>
         </field>


### PR DESCRIPTION
@mart-e 

testing and running in repository are not used anymore since they are 2 ir.config_parameter :
- runbot.workers
- runbot.running_max