### PR TITLE
cleanup empty lines which cause unpack errors

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -271,7 +271,7 @@ class runbot_repo(osv.osv):
         git_refs = git_refs.strip()
 
         refs = [[decode_utf(field) for field in line.split('\x00')] for line in git_refs.split('\n')]
-
+        refs = [ref for ref in refs if len(ref) == 8]  # cleanup empty lines which cause unpack errors below
         for name, sha, date, author, author_email, subject, committer, committer_email in refs:
             # create or get branch
             branch_ids = Branch.search(cr, uid, [('repo_id', '=', repo.id), ('name', '=', name)])


### PR DESCRIPTION
In runbot.odoo-community.org, the builds got stuck last week because of an exception in line 275 below (`Value Error: need more than 1 value to unpack`) when reaching a ref consisting of a single empty unicode string.

I did not research which commit caused this, and simply added this hot fix. 
