### PR TITLE
[master] [FIX] runbot: Fix no such file FETCH_HEAD

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -275,8 +275,11 @@ class runbot_repo(osv.osv):
             run(['git', 'clone', '--bare', repo.name, repo.path])
 
         # check for mode == hook
-        fetch_time = os.path.getmtime(os.path.join(repo.path, 'FETCH_HEAD'))
-        if repo.mode == 'hook' and repo.hook_time and dt2time(repo.hook_time) < fetch_time:
+	fname_fetch_head = os.path.join(repo.path, 'FETCH_HEAD')
+	fetch_time = None
+	if os.path.isfile(fname_fetch_head):
+            fetch_time = os.path.getmtime(fname_fetch_head)
+        if fetch_time and repo.mode == 'hook' and repo.hook_time and dt2time(repo.hook_time) < fetch_time:
             t0 = time.time()
             _logger.debug('repo %s skip hook fetch fetch_time: %ss ago hook_time: %ss ago', repo.name, int(t0 - fetch_time), int(t0 - dt2time(repo.hook_time)))
             return


### PR DESCRIPTION
Steps to reproduce issue:
 1. Create a new database with runbot module installed.
 2. Create a new runbot.repo with mode: `hook`
 3. Press button "update"

Expected:
 1. Repo updated

Saw:
 1. Next error
<img width="1280" alt="captura de pantalla 2015-09-26 a las 2 35 01 p m" src="https://cloud.githubusercontent.com/assets/6644187/10119505/6427b660-645d-11e5-8dcd-a8723b08ef6c.png">
