### PR TITLE
[IMP] runbot: blacklist a couple of POS related modules

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -706,7 +706,8 @@ class runbot_build(osv.osv):
 
     def filter_modules(self, cr, uid, modules, available_modules, explicit_modules):
         blacklist_modules = set(['auth_ldap', 'document_ftp', 'base_gengo',
-                                 'website_gengo', 'website_instantclick'])
+                                 'website_gengo', 'website_instantclick',
+                                 'pos_cache', 'pos_blackbox_be'])
 
         mod_filter = lambda m: (
             m in available_modules and


### PR DESCRIPTION
- pos_blackbox_be: because it makes the POS unuseable without a blackbox
- pos_cache: because it's too confusing for runbot users, everytime they
             update a product they have to also update the cache, but
             most people don't realise that.