### PR TITLE
[9.0][FIX] Do not give warning/yellow branches just on translation errors.

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -43,7 +43,7 @@ _logger = logging.getLogger(__name__)
 #----------------------------------------------------------
 
 _re_error = r'^(?:\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ (?:ERROR|CRITICAL) )|(?:Traceback \(most recent call last\):)$'
-_re_warning = r'^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ WARNING '
+_re_warning = r'(?!.*ir_translation.*)^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ WARNING.*'
 _re_job = re.compile('job_\d')
 
 # increase cron frequency from 0.016 Hz to 0.1 Hz to reduce starvation and improve throughput with many workers


### PR DESCRIPTION
Runbot should not have yellow branches / branches in warning for errors like these:
2017-06-26 09:09:34,239 11218 WARNING 233335-refs-heads-8-0-3063-order-split-60f4d3-all openerp.addons.base.ir.ir_translation: module web_ir_actions_act_window_page: no translation for language nl