### PR TITLE
[9.0][FIX] no error on traceback

### DIFF
--- a/runbot/runbot.py
+++ b/runbot/runbot.py
@@ -42,7 +42,7 @@ _logger = logging.getLogger(__name__)
 # Runbot Const
 #----------------------------------------------------------
 
-_re_error = r'^(?:\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ (?:ERROR|CRITICAL) )|(?:Traceback \(most recent call last\):)$'
+_re_error = r'^(?:\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ (?:ERROR|CRITICAL) )'
 _re_warning = r'^\d{4}-\d\d-\d\d \d\d:\d\d:\d\d,\d{3} \d+ WARNING '
 _re_job = re.compile('job_\d')
 


### PR DESCRIPTION
Tracebacks are often generated during tests to show were something happened. Never seen a real error with this.