### PR TITLE
[FIX] runbot: add dependency on base_setup

### DIFF
--- a/runbot/__openerp__.py
+++ b/runbot/__openerp__.py
@@ -5,7 +5,7 @@
     'version': '1.3',
     'description': "Runbot",
     'author': 'Odoo SA',
-    'depends': ['website'],
+    'depends': ['website', 'base_setup'],
     'external_dependencies': {
         'python': ['matplotlib'],
     },


### PR DESCRIPTION
To install properly, Runbot needs to find base.menu_config which is
defined in base_setup res_config_view.